### PR TITLE
피부 사진 아닌 경우 예외 처리 & 피부 미용 분석 코드 흐름 수정

### DIFF
--- a/src/main/java/com/example/capstone/aibeauty/controller/SkinAnalysisController.java
+++ b/src/main/java/com/example/capstone/aibeauty/controller/SkinAnalysisController.java
@@ -32,7 +32,7 @@ public class SkinAnalysisController {
         } catch (RuntimeException e) {
             return ResponseEntity.status(500).body(Map.of("message", e.getMessage()));
         } catch (IOException e) {
-            return ResponseEntity.status(500).body(Map.of("message", "요청 처리 중 오류가 발생했습니다.a"));
+            return ResponseEntity.status(500).body(Map.of("message", "요청 처리 중 오류가 발생했습니다."));
         }
     }
 }

--- a/src/main/java/com/example/capstone/aidisease/controller/DiagnosisController.java
+++ b/src/main/java/com/example/capstone/aidisease/controller/DiagnosisController.java
@@ -24,36 +24,40 @@ public class DiagnosisController {
     @PostMapping
     public ResponseEntity<?> diagnose(@RequestParam("image") MultipartFile file) { //"image" 키에 해당하는 값
 
-        //비어 있는 파일 검사
+        // 비어 있는 파일 검사
         if (file.isEmpty()) {
             return ResponseEntity
                     .badRequest()
                     .body(Map.of("message", "비어 있는 이미지 파일이 포함되어 있습니다."));
         }
 
-        //파일 크기 검사 (10MB 초과 금지)
+        // 파일 크기 검사 (10MB 초과 금지)
         if (file.getSize() > 10 * 1024 * 1024) {
             return ResponseEntity
                     .badRequest()
                     .body(Map.of("message", "이미지는 10MB를 초과할 수 없습니다."));
         }
 
-        //이미지 해상도 검사
+        // 이미지 해상도 검사
         try {
             BufferedImage image = ImageIO.read(file.getInputStream());
             if (image == null) {
                 return ResponseEntity.badRequest().body(Map.of("message", "올바르지 않은 이미지 형식입니다."));
             }
             if (image.getWidth() < 200 || image.getHeight() < 200) {
-                return ResponseEntity.badRequest().body(Map.of("message", "이미지 해상도는 최소 300x300 이상이어야 합니다."));
+                return ResponseEntity.badRequest().body(Map.of("message", "이미지 해상도는 최소 200x200 이상이어야 합니다."));
             }
         } catch (Exception e) {
             return ResponseEntity.badRequest().body(Map.of("message", "이미지 해상도 검사 중 오류가 발생했습니다."));
         }
 
-        //피부질환진단
-        DiagnosisResultResponse result = diagnosisService.diagnose(file);
-        return ResponseEntity.ok(result);
+        // 피부질환진단
+        try {
+            DiagnosisResultResponse result = diagnosisService.diagnose(file);
+            return ResponseEntity.ok(result);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(Map.of("message", e.getMessage()));
+        }
     }
 
     // 피부 질환 추가 정보

--- a/src/main/java/com/example/capstone/aidisease/service/DiagnosisService.java
+++ b/src/main/java/com/example/capstone/aidisease/service/DiagnosisService.java
@@ -24,7 +24,7 @@ public class DiagnosisService {
 
     public DiagnosisResultResponse diagnose(MultipartFile file) {
 
-        //AI 서버로 이미지 전송 (AI 서버 지금 무료 이용 중이라 수시로 바뀜)
+        // AI 서버로 이미지 전송 (AI 서버 지금 무료 이용 중이라 수시로 바뀜)
         String aiUrl = "https://59ef-223-195-38-166.ngrok-free.app/disease"; //AI 서버 진단 API 주소
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.MULTIPART_FORM_DATA); //전송할 데이터 multipart/form-data 명시
@@ -32,33 +32,27 @@ public class DiagnosisService {
         MultiValueMap<String, Object> body = new LinkedMultiValueMap<>(); //요청 본문에 이미지 파일 추가
         body.add("image", file.getResource()); //file.getResource() = file을 리소스로 변환
 
-        //최종 요청 객체 구성 (본문 + 헤더 합치기)
+        // 최종 요청 객체 구성 (본문 + 헤더 합치기)
         HttpEntity<MultiValueMap<String, Object>> requestEntity = new HttpEntity<>(body, headers);
 
-        //RestTemplate을 이용해 AI 서버에 POST 요청 전송
-        //응답은 JSON 형태 Map으로 받아옴
+        // RestTemplate을 이용해 AI 서버에 POST 요청 전송
+        // 응답은 JSON 형태 Map으로 받아옴
         ResponseEntity<Map> aiResponse = restTemplate.postForEntity(aiUrl, requestEntity, Map.class);
 
-        //AI 분석 결과 파싱
+        // AI 분석 결과 파싱
         String disease = (String) aiResponse.getBody().get("Disease");
         double probability = Double.parseDouble(aiResponse.getBody().get("Probability").toString());
 
-        // 피부 질환이 아닌 경우 응답 빌드
+        // 피부 질환이 아닌 경우 예외 처리
         if ("피부질환없음".equals(disease)) {
-            return DiagnosisResultResponse.builder()
-                    .disease(disease)
-                    .probability(probability)
-                    .treatment("없음")
-                    .source("없음")
-                    .imageUrl("없음")
-                    .build();
+            throw new IllegalArgumentException("피부 질환이 감지되지 않았습니다. 피부가 촬영된 이미지인지 확인 후 다시 업로드해주세요.");
         }
 
-        //DB에서 질환 정보 조회
+        // DB에서 질환 정보 조회
         DiseaseTreatment treatmentInfo = treatmentRepository.findByDisease(disease)
                 .orElseThrow(() -> new RuntimeException("등록된 질환 정보가 없습니다: " + disease));
 
-        //응답 빌드
+        // 응답 빌드
         return DiagnosisResultResponse.builder()
                 .disease(disease)
                 .probability(probability)


### PR DESCRIPTION
피부 질환 및 피부 미용 -> ai에 보냈을 때 피부 사진이 아닌 경우 (얼굴 사진 인식 못하거나 질환 사진 아니거나 등) 예외 처리
피부 미용 분석 코드 흐름 수정 (ai 분석 요청 -> s3 이미지 저장 -> 기존 분석 결과 삭제 -> DB에 새로운 분석 결과 저장)